### PR TITLE
Fixed missing zip error in Phabricator install

### DIFF
--- a/vars/Ubuntu-18.yml
+++ b/vars/Ubuntu-18.yml
@@ -16,6 +16,7 @@ default_phabricator_packages:
   - php7.2-json
   - php7.2-mbstring
   - php7.2-apcu
+  - php7.2-zip
   - python-pip
   - exim4
   - subversion


### PR DESCRIPTION
Currently, the installation returns an setup issue because php7.2-zip is missing. Installing the package fixes the issue.