### PR TITLE
Make the repository location be configurable through ansible defaults

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,8 @@ phabricator_protocol: https
 server_url: phab.example.com
 
 web_root: /var/www
+# Set the path to the local repository
+repository_path: "/var/repo"
 
 database_config:
   user: phabricator

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -13,6 +13,10 @@
   command: "{{ web_root }}/phabricator/bin/config set phabricator.base-uri '{{ phabricator_protocol }}://{{ server_url }}/'"
   changed_when: False
 
+- name: set repository default-local
+  command: "{{ web_root }}/phabricator/bin/config set  repository.default-local-path '{{ repository_path }}'"
+  changed_when: False
+
 - name: set daemon user
   command: "{{ web_root }}/phabricator/bin/config set phd.user '{{ users.daemon }}'"
   changed_when: False

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -245,7 +245,7 @@
 
 - name: Creates repo directory
   file:
-    path: {{ repository_path }}
+    path: "{{ repository_path }}"
     state: directory
     owner: "{{ users.daemon }}"
     group: "{{ users.daemon }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -245,7 +245,7 @@
 
 - name: Creates repo directory
   file:
-    path: /var/repo
+    path: {{ repository_path }}
     state: directory
     owner: "{{ users.daemon }}"
     group: "{{ users.daemon }}"


### PR DESCRIPTION
Since the repository is one of the key parts of Phabricator (both in terms of size + security requirements), it is convenient to be able to configure the location of this directory.